### PR TITLE
added sync_storage method

### DIFF
--- a/label_studio_sdk/client.py
+++ b/label_studio_sdk/client.py
@@ -191,3 +191,35 @@ class Client(object):
         response = self.session.request(method, self.get_url(url), headers=headers, *args, **kwargs)
         response.raise_for_status()
         return response
+
+    def sync_storage(self, storage_type, storage_id):
+        """Synchronize Cloud Storage.
+
+        Parameters
+        ----------
+        storage_type: string
+            Specify the type of the storage container.
+        storage_id: int
+            Specify the storage ID of the storage container.
+
+        Returns
+        -------
+        dict:
+            containing the same fields as in the original storage request and:
+
+        id: int
+            Storage ID
+        type: str
+            Type of storage
+        created_at: str
+            Creation time
+        last_sync: str
+            Time last sync finished, can be empty.
+        last_sync_count: int
+            Number of tasks synced in the last sync
+        """
+
+        response = self.make_request(
+            "POST", f"/api/storages/{storage_type}/{str(storage_id)}/sync"
+        )
+        return response.json()


### PR DESCRIPTION
Add a new sync_storage method to the SDK in the client class, may not be needed it could be done with `ls.make_request` but I am submitting it anyway.  

Here is an example of creating a project, attaching S3 storage, and synchronizing storage.  This would result in a project that is ready to start labeling.  All variables have been omitted to protect account information. 

```
from label_studio_sdk import Client

## Set variables
# aws_access_key_id, aws_secret_access_key, aws_bucket_name, aws_bucket_prefix
# label_studio_url, label_studio_access_token, label_config

## Create Connection with SDK
ls = Client(url=label_studio_url, api_key=label_studio_access_token)

## Create Project with SDK
project = ls.start_project(title="pull_request", label_config=label_config)

## Attach storage to project with SDK
storage = project.connect_s3_import_storage(
    bucket=aws_bucket_name,
    prefix=aws_bucket_prefix,
    use_blob_urls=True,
    aws_access_key_id=aws_access_key_id,
    aws_secret_access_key=aws_secret_access_key,
)

## Synchronize storage with SDK
ls.sync_storage(storage_type=storage["type"], storage_id=storage["id"])
```

  


