### PR TITLE
[fix] Optional org_membership for community edition

### DIFF
--- a/label_studio_sdk/users.py
+++ b/label_studio_sdk/users.py
@@ -31,7 +31,7 @@ class User(BaseModel):
     initials: str
     phone: str
     active_organization: int
-    org_membership: List[OrgMembership]
+    org_membership: Optional[List[OrgMembership]]
     client: Client
 
     class Config:


### PR DESCRIPTION
Fixes issue #22 
Correct pydantic validation error when doing `Client.get_users()` using community edition.