### PR TITLE
Allow client extra headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,6 @@ build:
 
 deploy:
 	python3 deploy.py
+
+test:
+	pytest tests

--- a/label_studio_sdk/client.py
+++ b/label_studio_sdk/client.py
@@ -14,7 +14,7 @@ HEADERS = {}
 
 class Client(object):
 
-    def __init__(self, url, api_key, session=None):
+    def __init__(self, url, api_key, session=None, extra_headers: dict = None):
         """ Initialize the client. Do this before using other Label Studio SDK classes and methods in your script.
 
         Parameters
@@ -26,10 +26,15 @@ class Client(object):
             User token for the API. You can find this on your user account page in Label Studio.
         session: requests.Session()
             If None, a new one is created.
+        extra_headers: dict
+            Additional headers that will be passed to each http request
         """
         self.url = url.rstrip('/')
         self.api_key = api_key
         self.session = session or self.get_session()
+        self.headers = {'Authorization': f'Token {self.api_key}'}
+        if extra_headers:
+            self.headers.update(extra_headers)
 
     def check_connection(self):
         """ Call Label Studio /health endpoint to check the connection to the server.
@@ -187,7 +192,6 @@ class Client(object):
         if 'timeout' not in kwargs:
             kwargs['timeout'] = TIMEOUT
         logger.debug(f'{method}: {url} with args={args}, kwargs={kwargs}')
-        headers = {'Authorization': f'Token {self.api_key}'}
-        response = self.session.request(method, self.get_url(url), headers=headers, *args, **kwargs)
+        response = self.session.request(method, self.get_url(url), headers=self.headers, *args, **kwargs)
         response.raise_for_status()
         return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 lxml>=4.2.5
 requests>=2.22.0,<3
 pydantic==1.8.2
+pytest==6.2.5
+setuptools==57.0.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,16 +1,22 @@
-# -------------------------------  Copyright ---------------------------------
-# This software has been developed by Orange TGI/DATA-IA/AITT/aRod
-# Copyright (c) Orange TGI Data/IA 2021
-#
-# COPYRIGHT: This file is the property of Orange TGI.
-# Copyright Orange TGI 2021, All Rights Reserved
-#
-# This software is the confidential and proprietary information of Orange TGI.
-#
-# You shall not disclose such Confidential Information and shall use it only
-# in accordance with the terms of the license agreement you entered into with
-# Orange TGI.
-#
-# AUTHORS      : Orange TGI  TGI/DATA-IA/AITT/aRod
-# EMAIL        : data-ia.aitt-dev-rennes@orange.com
-# ----------------------------------------------------------------------------
+from unittest.mock import patch
+
+from label_studio_sdk import Client
+
+
+def test_client_headers():
+    client = Client(url='http://fake.url', api_key='fake_key',
+                    extra_headers={'Proxy-Authorization': 'Bearer fake_bearer'})
+    with patch('requests.Session.request') as mocked_get:
+        mocked_get.return_value.status_code = 200
+        client.check_connection()
+        args, kwargs = mocked_get.call_args
+        assert kwargs['headers'] == {'Authorization': f'Token fake_key', 'Proxy-Authorization': 'Bearer fake_bearer'}
+
+
+def test_client_no_extra_headers():
+    client = Client(url='http://fake.url', api_key='fake_key')
+    with patch('requests.Session.request') as mocked_get:
+        mocked_get.return_value.status_code = 200
+        client.check_connection()
+        args, kwargs = mocked_get.call_args
+        assert kwargs['headers'] == {'Authorization': f'Token fake_key'}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,16 @@
+# -------------------------------  Copyright ---------------------------------
+# This software has been developed by Orange TGI/DATA-IA/AITT/aRod
+# Copyright (c) Orange TGI Data/IA 2021
+#
+# COPYRIGHT: This file is the property of Orange TGI.
+# Copyright Orange TGI 2021, All Rights Reserved
+#
+# This software is the confidential and proprietary information of Orange TGI.
+#
+# You shall not disclose such Confidential Information and shall use it only
+# in accordance with the terms of the license agreement you entered into with
+# Orange TGI.
+#
+# AUTHORS      : Orange TGI  TGI/DATA-IA/AITT/aRod
+# EMAIL        : data-ia.aitt-dev-rennes@orange.com
+# ----------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from label_studio_sdk import Client
+from label_studio_sdk.client import Client
 
 
 def test_client_headers():


### PR DESCRIPTION
This pull request aims to make extra headers possible for http requests.
Indeed, deploying LabelStudio may require specific headers as Proxy-Authorization.

Current implementation adds a dict parameter in the client constructor. This may includes extra keys that will be added to the "basic" header `{'Authorization': f'Token {self.api_key}'}`

Run the unit test with make :
```
make test
```