### PR TITLE
Allow to provide Path instance as tasks file

### DIFF
--- a/label_studio_sdk/project.py
+++ b/label_studio_sdk/project.py
@@ -5,6 +5,7 @@ import json
 
 from enum import Enum, auto
 from random import sample, shuffle
+from pathlib import Path
 from typing import Optional, Union, List, Dict, Callable
 from .client import Client
 from .utils import parse_config
@@ -426,7 +427,7 @@ class Project(Client):
                 json=tasks,
                 params=params
             )
-        elif isinstance(tasks, str):
+        elif isinstance(tasks, (str, Path)):
             # try import from file
             if not os.path.isfile(tasks):
                 raise LabelStudioException(f'Not found import tasks file {tasks}')
@@ -437,6 +438,8 @@ class Project(Client):
                     files={'file': f},
                     params=params
                 )
+        else:
+            raise TypeError(f'Not supported type provided as "tasks" argument: {type(tasks)}')
         return response.json()['task_ids']
 
     def export_tasks(self, export_type='JSON'):


### PR DESCRIPTION
Currently `Path` type is not supported when loading tasks from a file.

This code:
```python
from pathlib import Path
project.import_tasks(Path('./some/path/tasks.json')
```
produces this exception:
```python
+integration-tests-templater *failed* |     def import_tasks(self, tasks, preannotated_from_fields: List = None):
+integration-tests-templater *failed* |         """ Import JSON-formatted labeling tasks. Tasks can be unlabeled or contain predictions.
+integration-tests-templater *failed* |                                                                                                                                    
+integration-tests-templater *failed* |         Parameters                                                                                                                 
+integration-tests-templater *failed* |         ----------                                                                                                                 
+integration-tests-templater *failed* |         tasks: list of dicts | dict | path to file                                                                                 
+integration-tests-templater *failed* |             Tasks in <a href="https://labelstud.io/guide/tasks.html#Basic-Label-Studio-JSON-format">                               
+integration-tests-templater *failed* |             Label Studio JSON format</a>                                                                                           
+integration-tests-templater *failed* |                                                                                                                                    
+integration-tests-templater *failed* |         preannotated_from_fields: list of strings                                                                                  
+integration-tests-templater *failed* |             Turns flat task JSON formatted like: `{"column1": value, "column2": value}` into Label Studio prediction               
+integration-tests-templater *failed* |             data format: `{"data": {"column1"..}, "predictions": [{..."column2"}]`                                                 
+integration-tests-templater *failed* |             Useful when all your data is stored in tabular format with one column dedicated to model predictions.                  
+integration-tests-templater *failed* |                                                                                                                                    
+integration-tests-templater *failed* |         Returns                                                                                                                    
+integration-tests-templater *failed* |         -------                                                                                                                    
+integration-tests-templater *failed* |         list of int                                                                                                                
+integration-tests-templater *failed* |             Imported task IDs                                                                                                      
+integration-tests-templater *failed* |                                                                                                                                    
+integration-tests-templater *failed* |         """                       
+integration-tests-templater *failed* |         params = {'return_task_ids': '1'}                                                                                          
+integration-tests-templater *failed* |         if preannotated_from_fields:  
+integration-tests-templater *failed* |             params['preannotated_from_fields'] = ','.join(preannotated_from_fields)
+integration-tests-templater *failed* |         if isinstance(tasks, (list, dict)):
+integration-tests-templater *failed* |             response = self.make_request( 
+integration-tests-templater *failed* |                 method='POST',                                                                                                     
+integration-tests-templater *failed* |                 url=f'/api/projects/{self.id}/import',
+integration-tests-templater *failed* |                 json=tasks,                                                                                                        
+integration-tests-templater *failed* |                 params=params                                                                                                      
+integration-tests-templater *failed* |             )                                                                                                                      
+integration-tests-templater *failed* |         elif isinstance(tasks, str):
+integration-tests-templater *failed* |             # try import from file                                                                                                 
+integration-tests-templater *failed* |             if not os.path.isfile(tasks):
+integration-tests-templater *failed* |                 raise LabelStudioException(f'Not found import tasks file {tasks}')                                                 
+integration-tests-templater *failed* |             with open(tasks, mode='rb') as f: 
+integration-tests-templater *failed* |                 response = self.make_request(                                                                                      
+integration-tests-templater *failed* |                     method='POST',
+integration-tests-templater *failed* |                     url=f'/api/projects/{self.id}/import',                                                                         
+integration-tests-templater *failed* |                     files={'file': f},
+integration-tests-templater *failed* |                     params=params
+integration-tests-templater *failed* |                 )
+integration-tests-templater *failed* | >       return response.json()['task_ids']
+integration-tests-templater *failed* | E       UnboundLocalError: local variable 'response' referenced before assignment

+integration-tests-templater *failed* | .venv/lib/python3.9/site-packages/label_studio_sdk/project.py:417: UnboundLocalError
```

Notice that exception is not helpful and confusing either.

This PR adds Path support and raises a helpful Exception is none of the if-statement branches match.