### PR TITLE
Propagate provided 'extra_headers' through `_create_from_id`

### DIFF
--- a/label_studio_sdk/project.py
+++ b/label_studio_sdk/project.py
@@ -410,7 +410,7 @@ class Project(Client):
 
     @classmethod
     def _create_from_id(cls, client, project_id, params=None):
-        project = cls(url=client.url, api_key=client.api_key, session=client.session)
+        project = cls(url=client.url, api_key=client.api_key, session=client.session, extra_headers=client.headers)
         if params and isinstance(params, dict):
             # TODO: validate project parameters
             project.params = params


### PR DESCRIPTION
fixes [45](https://github.com/heartexlabs/label-studio-sdk/issues/45)

This solution simple takes all headers from the used `Client`. The one thing I'm not 100% sure about is that it also uses `Authorization` headers, which means the provided `api_key` is not used anymore in practice (it's overwritten):

```python
# label_studio_sdk/client.py#53

        if api_key is not None:
            warnings.warn("A deprecation warning to fit accordingly to your deprecation policy", DeprecationWarning)
            credentials = ClientCredentials(api_key=api_key)
        self.api_key = credentials.api_key if credentials.api_key else self.get_api_key(credentials)

        # set headers
        self.headers = {'Authorization': f'Token {self.api_key}'}
        if extra_headers:
            self.headers.update(extra_headers)

```