### PR TITLE
Add update task method

### DIFF
--- a/label_studio_sdk/project.py
+++ b/label_studio_sdk/project.py
@@ -898,6 +898,26 @@ class Project(Client):
         response = self.make_request('GET', f'/api/tasks/{task_id}')
         return response.json()
 
+    def update_task(self, task_id, **kwargs):
+        """ Update specific task by ID.
+
+        Parameters
+        ----------
+        task_id: int
+            Task ID you want to update
+        kwargs: kwargs parameters
+            List of parameters to update. Check all available parameters [here](https://labelstud.io/api#operation/api_tasks_partial_update)
+
+        Returns
+        -------
+        dict:
+            Dict with updated task
+
+        """
+        response = self.make_request('PATCH', f'/api/tasks/{task_id}', json=kwargs)
+        response.raise_for_status()
+        return response.json()
+
     def create_prediction(
         self,
         task_id: int,


### PR DESCRIPTION
I added a method to allow for the updating of tasks (specifically for the addition of `meta` k:v pairs, for my use case) via the Python SDK.

I wasn't really sure how to go about adding tests, though the `CONTRIBUTING.md` document encourages us to do so. There aren't any pre-existing tests, so adding tests would probably be a pretty huge effort just for this one addition (since I'd have to think through the best way to test and mock up all these API calls etc). Happy to take guidance on this.