### PR TITLE
[fix] documentation of the return type of export_snapshot_list in project.py

### DIFF
--- a/label_studio_sdk/project.py
+++ b/label_studio_sdk/project.py
@@ -1644,17 +1644,18 @@ class Project(Client):
         -------
         Returns
         -------
-        List of dict with export snapshots with status:
-        id: int
-            Export ID
-        created_at: str
-            Creation time
-        status: str
-            Export status
-        created_by: dict
-            User data
-        finished_at: str
-            Finished time
+        List[dict]
+            List of dict with export snapshots with status:
+            id: int
+                Export ID
+            created_at: str
+                Creation time
+            status: str
+                Export status
+            created_by: dict
+                User data
+            finished_at: str
+                Finished time
         """
         response = self.make_request('GET', f'/api/projects/{self.id}/exports')
         return response.json()


### PR DESCRIPTION
The way my IDE (pycharm 2022) parses the docstring of export_snapshot_list, it returns an int.
![image](https://user-images.githubusercontent.com/53872150/202867217-5a3df5ce-9f6c-4825-8480-c641417c56bb.png)

However, it returns a list of dicts. This fixes it.