### PR TITLE
[fix]: add support for newer pydantic versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml>=4.2.5
 requests>=2.22.0,<3
-pydantic>=1.8.2
+pydantic~=1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml>=4.2.5
 requests>=2.22.0,<3
-pydantic==1.8.2
+pydantic>=1.8.2


### PR DESCRIPTION
Add compatibility with dependencies that bundle newer `pydantic` versions.

**Issue:** https://github.com/heartexlabs/label-studio-sdk/issues/75