### PR TITLE
feat: added delete snapshot method

### DIFF
--- a/label_studio_sdk/project.py
+++ b/label_studio_sdk/project.py
@@ -1965,18 +1965,15 @@ class Project(Client):
                 for chunk in response:
                     f.write(chunk)
         return response.status_code, filename
-    
-    def export_snapshot_delete(
-            self,
-            export_id: int
-    ):
+
+    def export_snapshot_delete(self, export_id: int):
         """Delete an export file by specified export ID
-        
+
         Parameters
         ----------
         export_id: int
             Existing Export ID from current project
-        
+
         Returns
         ----------
         Status code for operation
@@ -1985,7 +1982,7 @@ class Project(Client):
             'DELETE',
             f'/api/projects/{self.id}/exports/{export_id}',
         )
-        return response.status_code
+        return response.status_codee
 
     def get_files_from_tasks(self, tasks: Dict, get_tasks: bool = False):
         """Copy files from tasks to cache folder

--- a/label_studio_sdk/project.py
+++ b/label_studio_sdk/project.py
@@ -1965,6 +1965,27 @@ class Project(Client):
                 for chunk in response:
                     f.write(chunk)
         return response.status_code, filename
+    
+    def export_snapshot_delete(
+            self,
+            export_id: int
+    ):
+        """Delete an export file by specified export ID
+        
+        Parameters
+        ----------
+        export_id: int
+            Existing Export ID from current project
+        
+        Returns
+        ----------
+        Status code for operation
+        """
+        response = self.make_request(
+            'DELETE',
+            f'/api/projects/{self.id}/exports/{export_id}',
+        )
+        return response.status_code
 
     def get_files_from_tasks(self, tasks: Dict, get_tasks: bool = False):
         """Copy files from tasks to cache folder


### PR DESCRIPTION
Added method` export_snapshot_delete()` to the `Project` class to address the issue #80

I am not sure about the `export_id` param - I've added it like this to be consistent throughout the SDK, though in [API](https://labelstud.io/api#operation/api_projects_exports_delete) it is named as `export_pk`. 