### PR TITLE
Update links URL

### DIFF
--- a/docs/pdoc_templates/head.mako
+++ b/docs/pdoc_templates/head.mako
@@ -21,17 +21,17 @@
       type="text/css">
 
 <!-- Place this tag in your head or just before your close body tag. -->
-<script src="/js/redirects.js"></script>
-<script src="/js/jquery.min.js"></script>
-<script src="/js/search.js"></script>
-<script src="/js/highlightjs-badge.min.js"></script>
-<script src="/js/smooth-scroll.min.js"></script>
+<script src="http://labelstud.io.s3-website-us-east-1.amazonaws.com/js/redirects.js"></script>
+<script src="http://labelstud.io.s3-website-us-east-1.amazonaws.com/js/jquery.min.js"></script>
+<script src="/http://labelstud.io.s3-website-us-east-1.amazonaws.comjs/search.js"></script>
+<script src="http://labelstud.io.s3-website-us-east-1.amazonaws.com/js/highlightjs-badge.min.js"></script>
+<script src="http://labelstud.io.s3-website-us-east-1.amazonaws.com/js/smooth-scroll.min.js"></script>
 
-<link rel="stylesheet" href="/css/new-styles.css">
-<link rel="stylesheet" href="/css/search.css">
+<link rel="stylesheet" href="http://labelstud.io.s3-website-us-east-1.amazonaws.com/css/new-styles.css">
+<link rel="stylesheet" href="http://labelstud.io.s3-website-us-east-1.amazonaws.com/css/search.css">
 
 <!-- main page styles -->
-<link rel="stylesheet" href="/css/page.css">
+<link rel="stylesheet" href="http://labelstud.io.s3-website-us-east-1.amazonaws.com/css/page.css">
 
 
 

--- a/docs/pdoc_templates/menu.mako
+++ b/docs/pdoc_templates/menu.mako
@@ -489,6 +489,6 @@
   </nav>
 </header>
 
-<script src="/js/css.escape.js"></script>
-<script src="/js/common.js"></script>
+<script src="http://labelstud.io.s3-website-us-east-1.amazonaws.com/js/css.escape.js"></script>
+<script src="http://labelstud.io.s3-website-us-east-1.amazonaws.com/js/common.js"></script>
 <script src="https://label-studio-docs-new-theme.netlify.app/js/header.js"></script>


### PR DESCRIPTION
We’re moving the docs to a new theme and these script / css are pointing to the old theme.

To not break the site, I’m pointing the ressources to our old docs theme